### PR TITLE
chore(commonjs): Add support for commonjs and npm

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./dist/angular-bootstrap-multiselect');
+module.exports = 'btorfs.multiselect';

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "type": "git",
     "url": "https://github.com/bentorfs/angular-bootstrap-multiselect.git"
   },
+  "main": "index.js",
   "devDependencies": {
     "grunt": "~1.0.1",
     "grunt-bootlint": "~0.10.1",


### PR DESCRIPTION
Added btorfs.multiselect to module exports so that after installing via npm, the package can be required in the angular module dependency list such as:

angular.module('myApp', [require('angular-bootstrap-multiselect')]);

This is helpful for Browserify and Webpack.