### PR TITLE
fix(npm): Update webdriver only during npm (pre)test command - fixes …

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "protractor-screenshot-reporter": "0.0.5"
   },
   "scripts": {
-    "install": "node node_modules/protractor/bin/webdriver-manager update",
+    "pretest": "node node_modules/protractor/bin/webdriver-manager update",
     "test": "grunt ci"
   }
 }


### PR DESCRIPTION
…bentorfs/angular-bootstrap-multiselect/#32

Updating webdriver-manager is only required for testing and not when installing this package