### PR TITLE
options vector may be unavailable until after app finishes loading

### DIFF
--- a/src/multiselect.js
+++ b/src/multiselect.js
@@ -46,7 +46,7 @@
                 $scope.searchFilter = '';
 
                 $scope.resolvedOptions = [];
-                if (typeof $scope.options !== 'function') {
+                if ($scope.options && typeof $scope.options !== 'function') {
                     $scope.resolvedOptions = $scope.options;
                 }
 


### PR DESCRIPTION
The $scope options array was still "undefined" at the point where I was loading the library, causing a couple errors shortly afterwards when $scope.resolvedOptions was being worked with (and was also set to undefined).  Checking for undefined at app load time simply avoids the errors.

![image](https://user-images.githubusercontent.com/5885217/89819176-36924b80-db08-11ea-9f7f-a44ba450b0fe.png)
